### PR TITLE
Fix layout overflow for Simulation view

### DIFF
--- a/Simulation.html
+++ b/Simulation.html
@@ -11,7 +11,7 @@
             justify-content: center;
             background-color: #f0f2f5;
             margin: 0;
-            overflow: hidden;
+            overflow: auto;
         }
         #simulation-container {
             display: flex;
@@ -23,7 +23,8 @@
             border-radius: 8px;
             box-shadow: 0 4px 12px rgba(0,0,0,0.1);
             width: 98vw;
-            height: 95vh;
+            height: calc(100vh - 20px);
+            box-sizing: border-box;
         }
         h1 {
             margin-top: 0;


### PR DESCRIPTION
## Summary
- ensure Simulation.html fits inside the viewport

## Testing
- `python -m py_compile Train.py`

------
https://chatgpt.com/codex/tasks/task_e_68449348823883248d276f1eacfc6303